### PR TITLE
Changed imgCopy function to work in go 1.13

### DIFF
--- a/canvas/canvas2d.go
+++ b/canvas/canvas2d.go
@@ -177,8 +177,8 @@ func (c *Canvas2d) initFrameUpdate(rf RenderFunc) {
 // Does the actuall copy over of the image data for the 'render' call.
 func (c *Canvas2d) imgCopy() {
 	// golang buffer
-	ta := js.TypedArrayOf(c.image.Pix)
-	c.im.Get("data").Call("set", ta)
-	ta.Release()
+	var array js.Value = js.Global().Get("Uint8Array").New(len(c.image.Pix))
+	js.CopyBytesToJS(array, c.image.Pix)
+	c.im.Get("data").Call("set", array)
 	c.ctx.Call("putImageData", c.im, 0, 0)
 }


### PR DESCRIPTION
Function TypedArrayOf() was removed in Go 1.13. This commit replaces it with CopyBytesToJS.

This is a fix for #1, needs to be tested more (I only did very little testing)